### PR TITLE
Fixed linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@blackbaud/auth-client": "2.7.0",
     "@blackbaud/skyux": "2.25.0",
     "@blackbaud/skyux-builder": "1.22.0",
+    "@skyux-sdk/testing": "3.0.0",
     "@skyux/assets": "3.0.0",
     "@skyux/core": "3.0.2",
     "core-js": "2.4.1",

--- a/src/app/public/modules/i18n/i18n.module.spec.ts
+++ b/src/app/public/modules/i18n/i18n.module.spec.ts
@@ -1,0 +1,14 @@
+import {
+  expect
+} from '@skyux-sdk/testing';
+
+import {
+  SkyI18nModule
+} from './i18n.module';
+
+describe('SkyI18nModule', () => {
+  it('should export', () => {
+    const exportedModule = new SkyI18nModule();
+    expect(exportedModule).toBeDefined();
+  });
+});

--- a/src/app/public/modules/i18n/i18n.module.ts
+++ b/src/app/public/modules/i18n/i18n.module.ts
@@ -7,6 +7,14 @@ import {
 } from '@angular/http';
 
 import {
+  SkyAppAssetsService
+} from '@skyux/assets';
+
+import {
+  SkyAppWindowRef
+} from '@skyux/core';
+
+import {
   SkyAppHostLocaleProvider
 } from './host-locale-provider';
 
@@ -25,10 +33,19 @@ import {
   exports: [
     SkyAppResourcesPipe
   ],
+  imports: [
+    HttpModule
+  ],
   providers: [
-    HttpModule,
+    // This service is ultimately provided by Builder,
+    // but we need to add it to a module to avoid TSLint failures.
+    {
+      provide: SkyAppAssetsService,
+      useValue: SkyAppAssetsService
+    },
     SkyAppHostLocaleProvider,
-    SkyAppResourcesService
+    SkyAppResourcesService,
+    SkyAppWindowRef
   ]
 })
 export class SkyI18nModule { }


### PR DESCRIPTION
When consuming this module, TSLint reports that `Http`, `SkyAppAssetsService`, and `SkyAppWindowService` are not provided.