### PR TITLE
Removed inline loaders in preparation for webpack 4

### DIFF
--- a/src/app/public/testing/lib-resources-test.service.ts
+++ b/src/app/public/testing/lib-resources-test.service.ts
@@ -47,7 +47,7 @@ export class SkyLibResourcesTestService {
     }
 
     const resourcesContext = require.context(
-      `json-loader!${ROOT_DIR}/../..`,
+      `${ROOT_DIR}/../..`,
       true,
       /\.\/assets\/locales\/resources_en_US\.json$/
     );

--- a/src/app/public/testing/resources-test.service.ts
+++ b/src/app/public/testing/resources-test.service.ts
@@ -39,7 +39,7 @@ export class SkyAppResourcesTestService {
     let resourcesContext;
     if (ROOT_DIR.indexOf('public') === -1) {
       resourcesContext = require.context(
-        `json-loader!${ROOT_DIR}/..`,
+        `${ROOT_DIR}/..`,
         true,
         /\.\/assets\/locales\/resources_en_US\.json$/
       );
@@ -47,7 +47,7 @@ export class SkyAppResourcesTestService {
       // Source code for libraries is located in a different directory.
       // NOTE: We must duplicate the require statement to allow webpack to build it properly.
       resourcesContext = require.context(
-        `json-loader!${ROOT_DIR}/../..`,
+        `${ROOT_DIR}/../..`,
         true,
         /\.\/assets\/locales\/resources_en_US\.json$/
       );


### PR DESCRIPTION
Related: https://github.com/blackbaud/skyux-builder/pull/497

This will allow us to support both Webpack 2 and 4.