### PR TITLE
Fix circular ref with core

### DIFF
--- a/src/app/public/modules/i18n/host-locale-provider.ts
+++ b/src/app/public/modules/i18n/host-locale-provider.ts
@@ -2,9 +2,12 @@ import {
   Injectable
 } from '@angular/core';
 
+// A direct import is required to avoid a circular reference:
+// Core depends on i18n, which depends on core...
+// (This file will be removed entirely in the next major release.)
 import {
   SkyAppWindowRef
-} from '@skyux/core';
+} from '@skyux/core/modules/window/window-ref';
 
 import {
   Observable


### PR DESCRIPTION
**Failing e2e build, from Builder:**
https://travis-ci.org/blackbaud/skyux-builder/jobs/526048223

`Error: Unexpected value 'undefined' imported by the module 'SkyNumericModule'`

Works in Node 10+, but fails in Node 6/8. This should fix it.
