### PR TITLE
Adding resource name provider to allow SPAs to have a hook in the res…

### DIFF
--- a/src/app/public/modules/i18n/index.ts
+++ b/src/app/public/modules/i18n/index.ts
@@ -11,6 +11,7 @@ export * from './lib-resources.pipe';
 export * from './lib-resources.service';
 export * from './locale-info';
 export * from './locale-provider';
+export * from './resource-name-provider';
 export * from './resources.pipe';
 export * from './resources.service';
 export * from './resources';

--- a/src/app/public/modules/i18n/resource-name-provider.spec.ts
+++ b/src/app/public/modules/i18n/resource-name-provider.spec.ts
@@ -1,0 +1,14 @@
+import {
+  SkyAppResourceNameProvider
+} from './resource-name-provider';
+
+describe('Resource name provider', () => {
+  it('should return the input resouce name', (done) => {
+    const provider = new SkyAppResourceNameProvider();
+    const exampleResourceName = 'test-resource-name';
+    provider.getResourceName(exampleResourceName).subscribe((name) => {
+      expect(name).toEqual(exampleResourceName);
+      done();
+    });
+  });
+});

--- a/src/app/public/modules/i18n/resource-name-provider.ts
+++ b/src/app/public/modules/i18n/resource-name-provider.ts
@@ -1,0 +1,17 @@
+import {
+  Injectable
+} from '@angular/core';
+
+import {
+  Observable
+} from 'rxjs/Observable';
+
+import 'rxjs/add/observable/of';
+
+@Injectable()
+export class SkyAppResourceNameProvider {
+
+  public getResourceName(name: string): Observable<string> {
+    return Observable.of(name);
+  }
+}


### PR DESCRIPTION
…ource process to control which resource is actually returned for a requested resource name. This will be used for rebranding terms based on vertical, such as the Church need to rebrand Fundraiser to Relationship manager.