### PR TITLE
Updated CODEOWNERS to skyux-maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Blackbaud-BobbyEarl @Blackbaud-SteveBrush @Blackbaud-PaulCrowder
+* @blackbaud/skyux-maintainers


### PR DESCRIPTION
Updated the `CODEOWNERS`file to reference @blackbaud/skyux-maintainers team.  https://help.github.com/en/articles/about-code-owners

This works in conjunction with updating the master branch policy to require a PR + require an approval from a code owner.

![Screen Shot 2019-08-27 at 1 17 06 PM](https://user-images.githubusercontent.com/4612419/63793192-28362a00-c8cd-11e9-863d-e218d7a18862.png)

This setup will allow our SKY UX deputies program to function in the main repo but still require our permission to merge.