### PR TITLE
Don't replace tokens with missing parameters

### DIFF
--- a/src/app/public/utils/format.spec.ts
+++ b/src/app/public/utils/format.spec.ts
@@ -12,4 +12,12 @@ describe('Format', () => {
 
     expect(result).toBe('This is the first test string. It worked!');
   });
+
+  it('should not replace tokens with missing parameter values', () => {
+    const result = Format.formatText(
+      'This is the {0} test string.'
+    );
+
+    expect(result).toBe('This is the {0} test string.');
+  });
 });

--- a/src/app/public/utils/format.ts
+++ b/src/app/public/utils/format.ts
@@ -9,7 +9,8 @@ export class Format {
     return String(format).replace(
       /\{(\d+)\}/g,
       function (match, capture): string {
-        return args[parseInt(capture, 10)];
+        const argsIndex = parseInt(capture, 10);
+        return args[argsIndex] === undefined ? match : args[argsIndex];
       }
     );
   }


### PR DESCRIPTION
This fixes an issue with using a tokenized resource string with the new format component in `@skyux/layout`.