### PR TITLE
Made assets service optional and removed provider from module

### DIFF
--- a/src/app/public/modules/i18n/i18n.module.ts
+++ b/src/app/public/modules/i18n/i18n.module.ts
@@ -7,10 +7,6 @@ import {
 } from '@angular/common/http';
 
 import {
-  SkyAppAssetsService
-} from '@skyux/assets';
-
-import {
   SkyLibResourcesPipe
 } from './lib-resources.pipe';
 
@@ -43,12 +39,6 @@ import {
     HttpClientModule
   ],
   providers: [
-    // This service is ultimately provided by Builder,
-    // but we need to add it to a module to avoid TSLint failures.
-    {
-      provide: SkyAppAssetsService,
-      useValue: SkyAppAssetsService
-    },
     SkyAppLocaleProvider,
     SkyAppResourcesService,
     SkyLibResourcesService

--- a/src/app/public/modules/i18n/resources.service.spec.ts
+++ b/src/app/public/modules/i18n/resources.service.spec.ts
@@ -132,10 +132,6 @@ describe('Resources service', () => {
     request.flush(testResources);
   }
 
-  beforeEach(() => {
-    mockAssetsService = undefined;
-  });
-
   describe('without an assets service', () => {
     beforeEach(() => {
       configureTestingModule(

--- a/src/app/public/modules/i18n/resources.service.spec.ts
+++ b/src/app/public/modules/i18n/resources.service.spec.ts
@@ -44,7 +44,8 @@ describe('Resources service', () => {
 
   function configureTestingModule(
     mockLocaleProvider?: any,
-    mockResourceNameProvider?: any
+    mockResourceNameProvider?: any,
+    excludeAssetsService?: boolean
   ): void {
     enUsUrl = 'https://example.com/locales/resources_en_US.json';
     enGbUrl = 'https://example.com/locales/resources_en_GB.json';
@@ -64,25 +65,31 @@ describe('Resources service', () => {
     };
 
     const providers: any[] = [
-      SkyAppAssetsService,
-      SkyAppResourcesService,
-      {
-        provide: SkyAppAssetsService,
-        useValue: {
-          getUrl: (path: string) => {
-            if (
-              // These represent unavailable locales.
-              path.indexOf('fr.json') >= 0 ||
-              path.indexOf('fr_FR.json') >= 0 ||
-              path.indexOf('es_MX.json') >= 0
-            ) {
-              return undefined;
-            }
-            return 'https://example.com/' + path;
-          }
-        }
-      }
+      SkyAppResourcesService
     ];
+
+    if (excludeAssetsService) {
+      mockAssetsService = undefined;
+    } else {
+      mockAssetsService = {
+        getUrl: (path: string) => {
+          if (
+            // These represent unavailable locales.
+            path.indexOf('fr.json') >= 0 ||
+            path.indexOf('fr_FR.json') >= 0 ||
+            path.indexOf('es_MX.json') >= 0
+          ) {
+            return undefined;
+          }
+          return 'https://example.com/' + path;
+        }
+      };
+
+      providers.push({
+        provide: SkyAppAssetsService,
+        useFactory: () => mockAssetsService
+      });
+    }
 
     if (mockLocaleProvider) {
       providers.push({
@@ -115,7 +122,6 @@ describe('Resources service', () => {
   }
 
   function injectServices(): any {
-    mockAssetsService = TestBed.inject(SkyAppAssetsService);
     resources = TestBed.inject(SkyAppResourcesService);
     httpMock = TestBed.inject(HttpTestingController);
   }
@@ -125,6 +131,28 @@ describe('Resources service', () => {
 
     request.flush(testResources);
   }
+
+  beforeEach(() => {
+    mockAssetsService = undefined;
+  });
+
+  describe('without an assets service', () => {
+    beforeEach(() => {
+      configureTestingModule(
+        undefined,
+        undefined,
+        true
+      );
+      injectServices();
+    });
+
+    it('should fall back to resource key', (done) => {
+      resources.getString('hi').pipe(take(1)).subscribe((value) => {
+        expect(value).toBe('hi');
+        done();
+      });
+    });
+  });
 
   describe('without a locale provider', () => {
     beforeEach(() => {

--- a/src/app/public/modules/i18n/resources.service.spec.ts
+++ b/src/app/public/modules/i18n/resources.service.spec.ts
@@ -142,7 +142,7 @@ describe('Resources service', () => {
       injectServices();
     });
 
-    it('should fall back to resource key', (done) => {
+    it('should fall back to the specified resource key', (done) => {
       resources.getString('hi').pipe(take(1)).subscribe((value) => {
         expect(value).toBe('hi');
         done();

--- a/src/app/public/modules/i18n/resources.service.ts
+++ b/src/app/public/modules/i18n/resources.service.ts
@@ -62,7 +62,7 @@ export class SkyAppResourcesService {
   constructor(
     private http: HttpClient,
     /* tslint:disable-next-line no-forward-ref */
-    @Inject(forwardRef(() => SkyAppAssetsService)) private assets: SkyAppAssetsService,
+    @Optional() @Inject(forwardRef(() => SkyAppAssetsService)) private assets: SkyAppAssetsService,
     @Optional() private localeProvider: SkyAppLocaleProvider,
     @Optional() private resourceNameProvider: SkyAppResourceNameProvider
   ) { }
@@ -171,6 +171,6 @@ export class SkyAppResourcesService {
   }
 
   private getUrlForLocale(locale: string): string {
-    return this.assets.getUrl(`locales/resources_${locale.replace('-', '_')}.json`);
+    return this.assets?.getUrl(`locales/resources_${locale.replace('-', '_')}.json`);
   }
 }


### PR DESCRIPTION
Providing `SkyAppAssetsService` caused issues for lazy-loaded routes because it would supersede the implemented assets service in the root app module. I made the provider optional and removed the erroneous provider from `SkyI18nModule` to fix it. I didn't have a way to test the issue that prompted the original change to provide the assets service, but the description of the issue in that PR doesn't seem like a valid issue to begin with. I guess we'll see.