### PR TITLE
Contrib > SkyAppResources - added getStrings

### DIFF
--- a/src/app/public/modules/i18n/resources.service.ts
+++ b/src/app/public/modules/i18n/resources.service.ts
@@ -102,16 +102,14 @@ export class SkyAppResourcesService {
   public getStrings<T extends ResourceDictionary>(dictionary: T): Observable<{ [K in keyof T]: string }> {
     const resources$: Record<string, Observable<string>> = {};
 
-    for (const resourceName in dictionary) {
-      if (dictionary.hasOwnProperty(resourceName)) {
-        const resource: string | [string, ...any[]] = dictionary[resourceName];
+    for (const objKey of Object.keys(dictionary)) {
+      const resource: string | [string, ...any[]] = dictionary[objKey];
 
-        if (typeof resource === 'string') {
-          resources$[resourceName] = this.getString(resource);
-        } else {
-          const [key, ...templateItems] = resource;
-          resources$[resourceName] = this.getString(key, ...templateItems);
-        }
+      if (typeof resource === 'string') {
+        resources$[objKey] = this.getString(resource);
+      } else {
+        const [key, ...templateItems] = resource;
+        resources$[objKey] = this.getString(key, ...templateItems);
       }
     }
 

--- a/src/app/public/modules/i18n/resources.service.ts
+++ b/src/app/public/modules/i18n/resources.service.ts
@@ -85,7 +85,9 @@ export class SkyAppResourcesService {
    *
    * This is similar to forkJoin's dictionary syntax.
    *
-   * @param dictionary a Record of **SomeObjectKey** to a **ResourceKey** entries.
+   * @param dictionary a Record of **SomeObjectKey** to a Value that is either
+   *   - (1) **ResourceKey**
+   *   - (2) or an **Array** where the first item is the **ResourceKey** and the other items are template args.
    * @return an `Observable` of a resource string dictionary in the same shape as the passed dictionary.
    *
    * @example


### PR DESCRIPTION
**Why**
- Retrieving multiple localizations in Typescript can be unwieldy especially as the number of keys grow.
- I've seen a few Slack threads where devs have asked for a "batch" method of getting localized resources.
- I think this qualifies as a nice-to-have utility function. Not required but it makes getting multiple resource strings a bit easier.

**Benefits of this approach**
1. Minimizes mental overhead when grabbing multiple resources
2. Mimic's a familiar RxJS ForkJoin + Dictionary syntax
3. Strong typing 
    - The return type is an Observable with all the keys in the input dictionary.
    - Intellisense knows what keys exist on the returned object.

**Other thoughts ❓**:
- Should we support passing an array as well to further mimic forkJoin Array Syntax?
    - I'm slightly opposed to this bc typing isn't as explicit _(its returns an Observable<string[]>)_ but I could see how some may find is useful.
    - If anything it should be possible to add in the future without a breaking change.

---

**Before**
```TS
// (OPTION 1) forkJoin Array syntax
//   Cons: You have to know the array order. 
//         If the source order changes you have to remember to update here as well.
//         Lots of repeated "this.skyAppResources.getString(...)"
forkJoin([
  this.skyAppResources.getString('hello_key'),
  this.skyAppResources.getString('hi_key'),
  this.skyAppResources.getString('template_key', 'a', 'b'),
]).pipe(
  tap(res => console.log(res[0], res[1], res[2])),
  tap(([exOne, exTwo, exThree]) => console.log(exOne, exTwo, exThree))
);

// (OPTION 2) forkJoin Dictionary Syntax
//   Pros: Strong typing 
//         You don't have to remember an arbitrary array order
//   Cons: Lots of repeated "this.skyAppResources.getString(...)"
const resources$ = forkJoin({
  exOne: this.skyAppResources.getString('hello_key'),
  exTwo: this.skyAppResources.getString('hi_key'),
  exThree: this.skyAppResources.getString('template_key', 'a', 'b'),
}).pipe(
  tap(res => console.log(res.exOne, res.exTwo, res.exThree)),
  tap(({ exOne, exTwo, exThree }) => console.log(exOne, exTwo, exThree))
);
```

**After**

```TS
const resources$ = skyAppResources.getStrings({
  exOne: 'hello_key',                      // Value is Resource Key String
  exTwo: ['hi_key'],                       // Value is an Array of [Resource Key]
  exThree: ['template_key', 'a', 'b'],     // Value is an Array of [Resource Key, ...templateArgs]
}).pipe(
  // Same strong typing 
  tap(res => console.log(res.exOne, res.exTwo, res.exThree)),
  tap(({ exOne, exTwo, exThree }) => console.log(exOne, exTwo, exThree))
);
```

