### PR TITLE
add support for accounting currency sign

### DIFF
--- a/src/app/public/modules/i18n/intl-number-formatter-options.ts
+++ b/src/app/public/modules/i18n/intl-number-formatter-options.ts
@@ -4,4 +4,5 @@ export interface SkyIntlNumberFormatterOptions {
   maximumFractionDigits?: number;
   currency?: string | null;
   currencyAsSymbol?: boolean;
+  currencySign?: string;
 }

--- a/src/app/public/modules/i18n/intl-number-formatter-options.ts
+++ b/src/app/public/modules/i18n/intl-number-formatter-options.ts
@@ -4,5 +4,5 @@ export interface SkyIntlNumberFormatterOptions {
   maximumFractionDigits?: number;
   currency?: string | null;
   currencyAsSymbol?: boolean;
-  currencySign?: string;
+  currencySign?: 'standard' | 'accounting';
 }

--- a/src/app/public/modules/i18n/intl-number-formatter.spec.ts
+++ b/src/app/public/modules/i18n/intl-number-formatter.spec.ts
@@ -84,4 +84,38 @@ describe('Intl number formatter', function () {
     }
   });
 
+  it('should format positive accounting values', function() {
+    const result = SkyIntlNumberFormatter.format(
+      100.12,
+      'en-US',
+      SkyIntlNumberFormatStyle.Currency,
+      {
+        currency: 'USD',
+        currencyAsSymbol: true,
+        currencySign: 'accounting'
+      }
+    );
+
+    verifyResult(result, '$100.12');
+  });
+
+  it('should format negative accounting values', function() {
+    const result = SkyIntlNumberFormatter.format(
+      -100.12,
+      'en-US',
+      SkyIntlNumberFormatStyle.Currency,
+      {
+        currency: 'USD',
+        currencyAsSymbol: true,
+        currencySign: 'accounting'
+      }
+    );
+
+    // IE 11 doesn't support currencySign
+    if (isIE && isWindows7) {
+      verifyResult(result, '-$100.12');
+    } else {
+      verifyResult(result, '($100.12)');
+    }
+  });
 });

--- a/src/app/public/modules/i18n/intl-number-formatter.ts
+++ b/src/app/public/modules/i18n/intl-number-formatter.ts
@@ -23,14 +23,16 @@ export abstract class SkyIntlNumberFormatter {
       minimumFractionDigits,
       maximumFractionDigits,
       currency,
-      currencyAsSymbol = false
+      currencyAsSymbol = false,
+      currencySign = 'standard'
     } = opts;
 
-    const options: Intl.NumberFormatOptions = {
+    const options: Intl.NumberFormatOptions & { currencySign: string } = {
       minimumIntegerDigits,
       minimumFractionDigits,
       maximumFractionDigits,
-      style: SkyIntlNumberFormatStyle[style].toLowerCase()
+      style: SkyIntlNumberFormatStyle[style].toLowerCase(),
+      currencySign
     };
 
     if (style === SkyIntlNumberFormatStyle.Currency) {


### PR DESCRIPTION
`currencySign = 'accounting'` formats negative numbers with parenthesis, such as ($100.00), [see docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#syntax). This is a common pattern in Financial products.

- Related to [skyux-core > SkyNumericPipe: expose INTL API Options](https://github.com/blackbaud/skyux-core/issues/179)
- Supported on [all browsers except IE11](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility)
- Have to shim the `Intl.NumberFormatOptions` type because Typescript did not add type support for it [until v4+](https://github.com/microsoft/TypeScript/pull/40709/commits/deba6f7d189799b1a03d7faf7d1511f28a23a809). 
  - After Sky 5 upgrade we should be able to remove the Type Shim since the Typescript version will be upgraded.