### PR TITLE
Contrib > Add support for accounting currency sign (#117)

### DIFF
--- a/src/app/public/modules/i18n/intl-number-formatter-options.ts
+++ b/src/app/public/modules/i18n/intl-number-formatter-options.ts
@@ -4,4 +4,5 @@ export interface SkyIntlNumberFormatterOptions {
   maximumFractionDigits?: number;
   currency?: string | null;
   currencyAsSymbol?: boolean;
+  currencySign?: 'standard' | 'accounting';
 }

--- a/src/app/public/modules/i18n/intl-number-formatter.spec.ts
+++ b/src/app/public/modules/i18n/intl-number-formatter.spec.ts
@@ -84,4 +84,38 @@ describe('Intl number formatter', function () {
     }
   });
 
+  it('should format positive accounting values', function() {
+    const result = SkyIntlNumberFormatter.format(
+      100.12,
+      'en-US',
+      SkyIntlNumberFormatStyle.Currency,
+      {
+        currency: 'USD',
+        currencyAsSymbol: true,
+        currencySign: 'accounting'
+      }
+    );
+
+    verifyResult(result, '$100.12');
+  });
+
+  it('should format negative accounting values', function() {
+    const result = SkyIntlNumberFormatter.format(
+      -100.12,
+      'en-US',
+      SkyIntlNumberFormatStyle.Currency,
+      {
+        currency: 'USD',
+        currencyAsSymbol: true,
+        currencySign: 'accounting'
+      }
+    );
+
+    // IE 11 doesn't support currencySign
+    if (isIE && isWindows7) {
+      verifyResult(result, '-$100.12');
+    } else {
+      verifyResult(result, '($100.12)');
+    }
+  });
 });

--- a/src/app/public/modules/i18n/intl-number-formatter.ts
+++ b/src/app/public/modules/i18n/intl-number-formatter.ts
@@ -23,14 +23,16 @@ export abstract class SkyIntlNumberFormatter {
       minimumFractionDigits,
       maximumFractionDigits,
       currency,
-      currencyAsSymbol = false
+      currencyAsSymbol = false,
+      currencySign = 'standard'
     } = opts;
 
-    const options: Intl.NumberFormatOptions = {
+    const options: Intl.NumberFormatOptions & { currencySign: string } = {
       minimumIntegerDigits,
       minimumFractionDigits,
       maximumFractionDigits,
-      style: SkyIntlNumberFormatStyle[style].toLowerCase()
+      style: SkyIntlNumberFormatStyle[style].toLowerCase(),
+      currencySign
     };
 
     if (style === SkyIntlNumberFormatStyle.Currency) {


### PR DESCRIPTION
Original contribution: https://github.com/blackbaud/skyux-i18n/pull/117

* add support for accounting currency sign

which formats negative numbers with parenthesis, such as ($100.00)

* specify currencySign values