### PR TITLE
fix: remove circular dependency on @skyux-sdk/testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4189,16 +4189,6 @@
         "comment-json": "4.1.1"
       }
     },
-    "@skyux-sdk/testing": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@skyux-sdk/testing/-/testing-5.1.1.tgz",
-      "integrity": "sha512-Cn4KNTKmi7Ze/50nbOUd+SpZiY5c16waXAYOW48iLPrwJdpgM5BsPH7MNhrga4pWzUyc1TtxaPh3Hi1WMdmyHg==",
-      "dev": true,
-      "requires": {
-        "axe-core": "3.5.6",
-        "tslib": "^2.3.1"
-      }
-    },
     "@skyux/assets": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@skyux/assets/-/assets-5.0.1.tgz",
@@ -5135,12 +5125,6 @@
           }
         }
       }
-    },
-    "axe-core": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
-      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
-      "dev": true
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@istanbuljs/nyc-config-typescript": "1.0.1",
     "@skyux-sdk/angular-builders": "5.0.0-beta.3",
     "@skyux-sdk/prettier-schematics": "5.0.0",
-    "@skyux-sdk/testing": "5.1.1",
     "@trivago/prettier-plugin-sort-imports": "2.0.2",
     "@types/jasmine": "3.8.2",
     "@types/node": "12.20.43",

--- a/projects/i18n/src/modules/i18n/i18n.module.spec.ts
+++ b/projects/i18n/src/modules/i18n/i18n.module.spec.ts
@@ -1,5 +1,4 @@
 import { SkyI18nModule } from './i18n.module';
-import { expect } from '@skyux-sdk/testing';
 
 describe('SkyI18nModule', () => {
   it('should export', () => {


### PR DESCRIPTION
`@skyux-sdk/testing` has a dependency on `@skyux/i18n`. Removing any reference to `@skyux-sdk/testing` to avoid a circular reference in the monorepo.